### PR TITLE
Skyblue/precise duration

### DIFF
--- a/eg/benchmark
+++ b/eg/benchmark
@@ -19,7 +19,7 @@ sub main {
 
     my $reader = MaxMind::DB::Reader->new( file => $file );
 
-    my $start = [gettimeofday]; 
+    my $start = [gettimeofday];
     for my $i (1 .. $iterations) {
         print "$i\n" if $i % 1000 == 0;
 


### PR DESCRIPTION
- time() just gives whole seconds - using Time::HiRes for greater precision when we calculate the duration.
- Also, expanded final output to give the iterations and the duration rather than just the iterations / duration.
